### PR TITLE
fix: signup with email sign in user if session exists

### DIFF
--- a/mobile/lib/providers/auth/auth_notifier_provider.dart
+++ b/mobile/lib/providers/auth/auth_notifier_provider.dart
@@ -27,12 +27,12 @@ class AuthNotifier extends _$AuthNotifier {
     );
   }
 
-  Future<void> signUpWithEmailAndPassword({
+  Future<Session?> signUpWithEmailAndPassword({
     required String email,
     required String password,
   }) async {
     final authRepository = await ref.read(authRepositoryProvider.future);
-    await authRepository.signUpWithEmailAndPassword(
+    return authRepository.signUpWithEmailAndPassword(
       email: email,
       password: password,
     );

--- a/mobile/lib/ui/authentication/pages/sign_up_page.dart
+++ b/mobile/lib/ui/authentication/pages/sign_up_page.dart
@@ -66,11 +66,23 @@ class SignUpForm extends HookConsumerWidget {
           (tsx) async {
             try {
               final notifier = tsx.get(authProvider.notifier);
-              await notifier.signUpWithEmailAndPassword(
+              final session = await notifier.signUpWithEmailAndPassword(
                 email: emailController.text.trim(),
                 password: passwordController.text.trim(),
               );
-              await router.replace(const HomeRoute());
+              if (session != null) {
+                await router.replace(const HomeRoute());
+                return;
+              }
+
+              scaffoldMessenger.showSnackBar(
+                const SnackBar(
+                  content: Text(
+                    'Check your email to confirm your account before signing in.',
+                  ),
+                ),
+              );
+              await router.replace(const SignInRoute());
             } on AuthRepositoryException catch (error, stackTrace) {
               ErrorLoggerService.instance.logError(
                 error,

--- a/mobile/lib/ui/splash/pages/splash_page.dart
+++ b/mobile/lib/ui/splash/pages/splash_page.dart
@@ -14,9 +14,7 @@ class SplashPage extends ConsumerWidget {
     switch (currentValue) {
       case AsyncLoading():
         return;
-      // This private field will be used later.
-      // ignore: unused_local_variable
-      case AsyncData(:final value?):
+      case AsyncData(:final value) when value != null: 
         context.replaceRoute(const HomeRoute());
       default:
         context.replaceRoute(const SignUpRoute());

--- a/mobile/test/ui/authentication/pages/sign_up_page_test.dart
+++ b/mobile/test/ui/authentication/pages/sign_up_page_test.dart
@@ -6,7 +6,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mobile/repositories/auth_repo/auth_repository.dart';
 import 'package:mobile/router/app_router.dart';
 import 'package:mobile/router/app_router.gr.dart';
-import 'package:mobile/ui/home/pages/home_page.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockAuthRepository extends Mock implements AuthRepository {}
@@ -136,7 +135,7 @@ void main() {
     );
   });
 
-  testWidgets('submits with valid values and navigates to home', (
+  testWidgets('submits with valid values and navigates to sign in', (
     tester,
   ) async {
     await pumpSignUpPage(tester);
@@ -164,9 +163,10 @@ void main() {
       ),
     ).called(1);
     expect(
-      find.byWidgetPredicate((widget) => widget is HomePage),
+      find.text('Check your email to confirm your account before signing in.'),
       findsOneWidget,
     );
+    expect(find.text('Sign In'), findsOneWidget);
   });
 
   testWidgets('shows snackbar when sign up fails', (tester) async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
The main change is that after signing up, users are prompted to check their email for confirmation and are redirected to the sign-in page, rather than being taken directly to the home page. The tests and related logic have been updated to reflect this behavior.

Fixes #52 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
